### PR TITLE
allow to storage arbitary type in Enemy

### DIFF
--- a/Classes/core/entity/enemy/Boss-1.cpp
+++ b/Classes/core/entity/enemy/Boss-1.cpp
@@ -40,11 +40,13 @@ void Boss1::on_tick(GridRef g) {
 }
 
 void Boss1::on_death(GridRef g) {
-    g.set_timeout(g.clock().with_duration_sec(30), [row = g.row, col = g.column](Map & map) {
-        auto boss2 = EnemyFactory<Boss2>{};
-        map.spawn_enemy_at(row, col, boss2);
-        return false;
-    });
+    g.set_timeout(
+        g.clock().with_duration_sec(30),
+        [row = g.row, col = g.column, route = this->route_](Map &map) {
+            auto boss2 = EnemyFactory<Boss2>{route};
+            map.spawn_enemy_at(row, col, boss2);
+            return false;
+        });
 }
 
 } // namespace core

--- a/Classes/core/entity/entity.h
+++ b/Classes/core/entity/entity.h
@@ -200,7 +200,7 @@ struct ExtraStorage {
     // `std::bad_any_cast` if type mismatch.
     //
     // `std::out_of_range` if key does not exist.
-    template <class T> T get_storage(const std::string &key) {
+    template <class T> T get_storage(const std::string &key) const {
         auto &value = this->storage_.at(key);
 
         return std::any_cast<T>(value);


### PR DESCRIPTION
## Example

```cpp
struct MyData {
    int x;
};
struct AnotherData {
    int x;
};
// add extra storage when constructing 
auto factory = EnemyFactory<AttackDown>({/* init Route */}, {{"my-data", MyData{.x = 0}}});

auto enemy = factory.construct(assign_id(), clock()); // done by Map
auto &enemy_ref = *enemy; // assuming we have got an enemy

auto my_data = enemy_ref.get_storage<MyData>("my-data");
std::cout << my_data.x;
enemy->set_storage("inserting-data", AnotherData {.x = 114514}); // add data
enemy->set_storage("my-data", MyData {.x = 42}); // modify data

// untested

auto &data = enemy _ref.get_storage<MyData&>("my-data");
data.x = 6; // in place modification
```