### PR TITLE
support build with sanitizer

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -22,7 +22,7 @@ jobs:
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
         os: [windows-latest]
-        build_type: [Release]
+        build_type: [Debug]
         c_compiler: [cl]
         include:
           - os: windows-latest
@@ -46,6 +46,7 @@ jobs:
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -S ${{ github.workspace }}
         -A Win32
+        -DTOWERDEFENCE_SANITIZER=ON
 
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,13 @@ if (XCODE)
     endif ()
 endif ()
 
+if (TOWERDEFENCE_SANITIZER)
+    if (WIN32)
+        message("disable annotation on windows")
+        add_compile_definitions("_DISABLE_VECTOR_ANNOTATION" "_DISABLE_STRING_ANNOTATION")
+    endif()
+endif()
+
 if (NOT DEFINED BUILD_ENGINE_DONE) # to test TowerDefence into root project
     set(COCOS2DX_ROOT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cocos2d)
     set(CMAKE_MODULE_PATH ${COCOS2DX_ROOT_PATH}/cmake/Modules/)
@@ -42,6 +49,19 @@ if (NOT DEFINED BUILD_ENGINE_DONE) # to test TowerDefence into root project
     include(CocosBuildSet)
     add_subdirectory(${COCOS2DX_ROOT_PATH}/cocos ${ENGINE_BINARY_PATH}/cocos/core)
 endif ()
+
+if (TOWERDEFENCE_SANITIZER)
+    if (WINDOWS)
+        message("enabling sanitizer")
+        add_compile_options("/fsanitize=address")
+        add_link_options("/fsanitize=address")
+        add_compile_definitions("TOWERDEFENCE_SANITIZER")
+    else()
+        message("enabling sanitizer")
+        add_compile_options(-fsanitize=undefined,address)
+        add_link_options(-fsanitize=undefined,address)
+    endif()
+endif()
 
 add_library(core
         Classes/core/map.cpp

--- a/asan.supp
+++ b/asan.supp
@@ -1,0 +1,1 @@
+interceptor_via_lib:rapidxml


### PR DESCRIPTION
[AddressSanitizer](https://learn.microsoft.com/en-us/cpp/sanitizers/asan?view=msvc-170) is a powerful tool to detect memory issues.

# Usage

1. download artifact from ci or pass `-DTOWERDEFENCE_SANITIZER=ON` to cmake and build
2. copy `clang_rt.asan_dynamic-i386.dll` and `clang_rt.asan_dynamic-i386.pdb` from your local msvc installation and put them against `Towerdefence.exe`
3. copy `asan.supp` from repo  and put it against `Towerdefence.exe`
4. open powershell, run `$env:ASAN_OPTIONS="suppressions=asan.supp"`
5. run `Start-Process -RedirectStandardError stderr.log -RedirectStandardOutput stdout.log .\TowerDefence.exe`
6. after program crahes, examine `stderr.log`