### PR TITLE
force new_progress >= 1 when updating timer

### DIFF
--- a/Classes/core/entity/entity.cpp
+++ b/Classes/core/entity/entity.cpp
@@ -17,7 +17,9 @@ auto update_by_interval(double interval, const timer::Clock &clk) {
         std::cout << std::format("old interval: {} new interval: {}", p.period,
                                  interval)
                   << std::endl;
-        if (interval != p.period) {
+        uint32_t next_period = std::max(UINT32_C(1), static_cast<uint32_t>(interval));
+
+        if (next_period != p.period) {
             auto progress =
                 static_cast<double>((clk.elapased_ - p.start) % p.period) /
                 p.period;
@@ -33,7 +35,6 @@ auto update_by_interval(double interval, const timer::Clock &clk) {
             p.start = (clk.elapased_ >= new_progress)
                           ? (clk.elapased_ - new_progress)
                           : 0;
-            uint32_t next_period = interval;
             p.period = (next_period > 0) ? next_period : 1;
             std::cout << std::format("new p.start: {}, p.period: {}", p.start,
                                      p.period)


### PR DESCRIPTION
After `67fce41`, timer will be triggered immediately after update if progress < 1 / new_interval. Forcing new_progress >= 1 as a workaround.